### PR TITLE
feat: add linear_label_ids input for labeling created tickets

### DIFF
--- a/.github/workflows/example-pipeline.yml
+++ b/.github/workflows/example-pipeline.yml
@@ -45,6 +45,7 @@ jobs:
           datadog_app_key: ${{ secrets.DATADOG_APP_KEY }}
           linear_api_key: ${{ secrets.LINEAR_API_KEY }}
           linear_team: 'ENG'
+          # linear_label_ids: 'label-uuid-1,label-uuid-2'  # Optional: comma-separated Linear label UUIDs
           hours_back: ${{ github.event.inputs.hours_back || '1' }}
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: 'Claude model override (leave empty for default)'
     required: false
     default: ''
+  linear_label_ids:
+    description: 'Comma-separated Linear label UUIDs to apply to created tickets (e.g. "label-uuid-1,label-uuid-2")'
+    required: false
+    default: ''
   slack_webhook_url:
     description: 'Slack incoming webhook URL. If provided, sends a summary notification.'
     required: false
@@ -171,6 +175,7 @@ runs:
           - team: "${{ inputs.linear_team }}"
           - title: "${{ inputs.ticket_prefix }} <concise error title>" (avoid parentheses in titles — use dashes instead)
           - priority: 2 (High) for critical errors, 3 (Normal) for regular errors
+          ${{ inputs.linear_label_ids != '' && format('- labelIds: [{0}]', inputs.linear_label_ids) || '' }}
 
           **IMPORTANT**: After calling `create_issue`, capture the `id`, `identifier`, and `url` from the response.
 


### PR DESCRIPTION
## Summary
- Adds optional `linear_label_ids` input (comma-separated UUIDs) to the monitor action
- When provided, passes `labelIds` to `create_issue` so tickets are automatically labeled
- Adds commented example in the example pipeline

## Test plan
- [ ] Configure `linear_label_ids` with valid label UUIDs and verify created tickets have the labels applied
- [ ] Verify omitting `linear_label_ids` still creates tickets without labels (backward compatible)