### PR TITLE
Improve RCA context handoff to custom prompt files

### DIFF
--- a/.github/workflows/example-pipeline.yml
+++ b/.github/workflows/example-pipeline.yml
@@ -48,6 +48,10 @@ jobs:
           # linear_label_ids: 'label-uuid-1,label-uuid-2'  # Optional: comma-separated Linear label UUIDs
           hours_back: ${{ github.event.inputs.hours_back || '1' }}
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          # --- Custom RCA (optional) ---
+          # rca_prompt_file: '.github/rca-instructions.md'
+          # additional_mcp_config: '{"logfire":{"command":"npx","args":["-y","logfire-mcp"],"env":{"LOGFIRE_READ_TOKEN":"${{ secrets.LOGFIRE_READ_TOKEN }}"}}}'
+          # additional_allowed_tools: 'mcp__logfire__arbitrary_query,mcp__logfire__find_exceptions_in_file'
 
   # ── Stage 2: Resolve each new ticket ──────────────────────────────
   resolve:

--- a/.github/workflows/example-pipeline.yml
+++ b/.github/workflows/example-pipeline.yml
@@ -45,6 +45,7 @@ jobs:
           datadog_app_key: ${{ secrets.DATADOG_APP_KEY }}
           linear_api_key: ${{ secrets.LINEAR_API_KEY }}
           linear_team: 'ENG'
+          # linear_label_ids: 'label-uuid-1,label-uuid-2'  # Optional: comma-separated Linear label UUIDs
           hours_back: ${{ github.event.inputs.hours_back || '1' }}
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,20 @@ Autonomous production error monitoring and resolution — as reusable GitHub Act
 │  │ Datadog  │───>│ Claude Code  │───>│ Linear Ticket Created │  │
 │  │ (errors) │    │ (analyze +   │    │ (fingerprinted,       │  │
 │  └──────────┘    │  deduplicate)│    │  deduplicated)        │  │
-│                  └──────────────┘    └───────────┬───────────┘  │
-│                                                  │              │
-│                                                  ▼              │
-│  ┌──────────┐    ┌──────────────┐    ┌───────────────────────┐  │
-│  │  Slack   │<───│  GitHub PR   │<───│ Claude Code           │  │
-│  │ (notify) │    │  (auto-fix)  │    │ (investigate + fix)   │  │
-│  └──────────┘    └──────────────┘    └───────────────────────┘  │
+│                  └──────┬───────┘    └───────────┬───────────┘  │
+│                         │                        │              │
+│       ┌─────────────────┤                        ▼              │
+│       ▼                 │                                       │
+│  ┌──────────┐    ┌──────┴───────┐    ┌───────────────────────┐  │
+│  │ MCP      │    │ Custom RCA   │    │ Claude Code           │  │
+│  │ Servers  │───>│ (optional)   │    │ (investigate + fix)   │  │
+│  │ (Logfire,│    └──────────────┘    └───────────┬───────────┘  │
+│  │ Grafana) │                                    │              │
+│  └──────────┘                                    ▼              │
+│                  ┌──────────────┐    ┌───────────────────────┐  │
+│  ┌──────────┐    │  GitHub PR   │<───│ Claude Code           │  │
+│  │  Slack   │<───│  (auto-fix)  │    │ (investigate + fix)   │  │
+│  │ (notify) │    └──────────────┘    └───────────────────────┘  │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -83,6 +90,10 @@ Scans Datadog for production errors and creates deduplicated Linear tickets.
 | `min_occurrences` | no | `3` | Min error count threshold |
 | `datadog_query` | no | `status:error OR status:critical` | Custom Datadog log query |
 | `claude_model` | no | _(empty)_ | Claude model override |
+| `linear_label_ids` | no | _(empty)_ | Comma-separated Linear label UUIDs to apply to created tickets |
+| `rca_prompt_file` | no | _(empty)_ | Path to a custom RCA instructions file (see [Custom Root Cause Analysis](#custom-root-cause-analysis)) |
+| `additional_mcp_config` | no | _(empty)_ | JSON object of additional MCP server configs to merge (see [Additional MCP Servers](#additional-mcp-servers)) |
+| `additional_allowed_tools` | no | _(empty)_ | Comma-separated list of additional tool names to allow |
 | `slack_webhook_url` | no | _(empty)_ | Slack webhook for summary notifications |
 
 #### Outputs
@@ -132,6 +143,95 @@ See [`.github/workflows/example-pipeline.yml`](.github/workflows/example-pipelin
 1. Runs the monitor on a cron schedule
 2. Automatically triggers the resolver for each new ticket
 3. Limits parallel resolution to 2 concurrent PRs
+
+## Custom Root Cause Analysis
+
+By default, the monitor creates tickets with a basic root cause analysis derived from the Datadog logs and stack traces. You can enhance this with a **custom RCA prompt file** that instructs Claude to use additional observability tools for deeper analysis.
+
+### How It Works
+
+1. Create an RCA instructions file in your repo (e.g., `.github/rca-instructions.md`)
+2. Configure additional MCP servers that provide observability tools
+3. Pass the file path and allowed tools to the action
+
+The monitor will read your instructions file and follow them to perform a deeper root cause analysis before creating tickets.
+
+### Example RCA Instructions File
+
+```markdown
+<!-- .github/rca-instructions.md -->
+## Root Cause Analysis Instructions
+
+For each error group, perform the following analysis using the available MCP tools:
+
+1. **Query Logfire** for the error fingerprint using `mcp__logfire__arbitrary_query`:
+   - Search for the error message pattern in the last 2 hours
+   - Look for upstream errors that may have caused the issue
+   - Check for latency spikes in related services
+
+2. **Find related exceptions** using `mcp__logfire__find_exceptions_in_file`:
+   - Check the affected file paths for recent exceptions
+   - Look for patterns across related files
+
+3. **Include in the ticket**:
+   - Timeline of events leading to the error
+   - Upstream service dependencies that failed
+   - Latency/throughput metrics around the time of the error
+   - Confidence level (high/medium/low) for the root cause
+```
+
+### Example Workflow with Custom RCA
+
+```yaml
+- uses: ask-commit/ai-oncall-agent@v1
+  with:
+    claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    datadog_api_key: ${{ secrets.DATADOG_API_KEY }}
+    datadog_app_key: ${{ secrets.DATADOG_APP_KEY }}
+    linear_api_key: ${{ secrets.LINEAR_API_KEY }}
+    rca_prompt_file: '.github/rca-instructions.md'
+    additional_mcp_config: '{"logfire":{"command":"npx","args":["-y","logfire-mcp"],"env":{"LOGFIRE_READ_TOKEN":"${{ secrets.LOGFIRE_READ_TOKEN }}"}}}'
+    additional_allowed_tools: 'mcp__logfire__arbitrary_query,mcp__logfire__find_exceptions_in_file'
+```
+
+## Additional MCP Servers
+
+The action ships with the Linear MCP server built in. You can connect additional MCP servers to give Claude access to more tools during analysis.
+
+### How It Works
+
+Pass a JSON object of MCP server configurations via `additional_mcp_config`. These are merged into the `.mcp.json` file alongside the built-in Linear server. You must also allowlist any tools from these servers via `additional_allowed_tools`.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    MCP Config Merging                            │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  Built-in:              Additional (user-provided):             │
+│  ┌──────────────────┐   ┌──────────────────────────────────┐    │
+│  │ linear-server    │ + │ logfire, grafana, pagerduty, ... │    │
+│  └──────────────────┘   └──────────────────────────────────┘    │
+│            │                          │                          │
+│            └────────────┬─────────────┘                          │
+│                         ▼                                        │
+│              ┌──────────────────┐                                │
+│              │   .mcp.json      │                                │
+│              │   (merged)       │                                │
+│              └──────────────────┘                                │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Supported MCP Servers
+
+Any MCP server that can be launched via `npx` or a local command works. Some examples:
+
+| Server | Use Case | Config Example |
+|--------|----------|----------------|
+| [Logfire](https://github.com/pydantic/logfire) | Query traces, find exceptions | `{"logfire":{"command":"npx","args":["-y","logfire-mcp"],"env":{"LOGFIRE_READ_TOKEN":"..."}}}` |
+| [Grafana](https://github.com/grafana/mcp-grafana) | Dashboard queries, alerts | `{"grafana":{"command":"npx","args":["-y","@grafana/mcp-server"],"env":{"GRAFANA_API_KEY":"..."}}}` |
+| [PagerDuty](https://github.com/PagerDuty/mcp-server-pagerduty) | Incident context | `{"pagerduty":{"command":"npx","args":["-y","@pagerduty/mcp-server"],"env":{"PAGERDUTY_API_KEY":"..."}}}` |
 
 ## Security & Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: ask-commit/ai-oncall-agent@v1
+      - uses: Autonomy-AI/ai-oncall-agent@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -65,7 +65,7 @@ To also **auto-fix** each new ticket, see the [full example pipeline](.github/wo
 
 ## Two Actions
 
-### `ask-commit/ai-oncall-agent@v1` — Error Monitor
+### `Autonomy-AI/ai-oncall-agent@v1` — Error Monitor
 
 Scans Datadog for production errors and creates deduplicated Linear tickets.
 
@@ -105,7 +105,7 @@ Scans Datadog for production errors and creates deduplicated Linear tickets.
 | `duplicates_done` | JSON array of duplicate tickets previously resolved |
 | `has_results` | `true` if any results were found |
 
-### `ask-commit/ai-oncall-agent/resolve@v1` — Issue Resolver
+### `Autonomy-AI/ai-oncall-agent/resolve@v1` — Issue Resolver
 
 Takes a Linear issue ID, investigates the root cause, implements a fix, and opens a PR.
 
@@ -183,7 +183,7 @@ For each error group, perform the following analysis using the available MCP too
 ### Example Workflow with Custom RCA
 
 ```yaml
-- uses: ask-commit/ai-oncall-agent@v1
+- uses: Autonomy-AI/ai-oncall-agent@v1
   with:
     claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,18 @@ inputs:
     description: 'Comma-separated Linear label UUIDs to apply to created tickets (e.g. "label-uuid-1,label-uuid-2")'
     required: false
     default: ''
+  rca_prompt_file:
+    description: 'Path to a file in the repo containing custom Root Cause Analysis instructions. If provided, Claude will read and follow this file for RCA instead of the built-in analysis. This lets you plug in your own observability stack (e.g., Logfire, Datadog APM, Honeycomb).'
+    required: false
+    default: ''
+  additional_mcp_config:
+    description: 'JSON object of additional MCP server configs to merge into .mcp.json. Use this to connect Claude to extra tools your RCA skill needs (e.g., Logfire, Grafana, PagerDuty MCP servers).'
+    required: false
+    default: ''
+  additional_allowed_tools:
+    description: 'Comma-separated list of additional tool names to allow beyond the defaults (e.g., "mcp__logfire__arbitrary_query,mcp__logfire__find_exceptions_in_file").'
+    required: false
+    default: ''
   slack_webhook_url:
     description: 'Slack incoming webhook URL. If provided, sends a summary notification.'
     required: false
@@ -80,19 +92,15 @@ runs:
     - name: Create MCP Config
       shell: bash
       run: |
-        cat > .mcp.json << EOF
-        {
-          "mcpServers": {
-            "linear-server": {
-              "command": "npx",
-              "args": ["-y", "@linear/mcp-server-linear"],
-              "env": {
-                "LINEAR_API_KEY": "${{ inputs.linear_api_key }}"
-              }
-            }
-          }
-        }
-        EOF
+        # Build base config with Linear server
+        BASE='{"mcpServers":{"linear-server":{"command":"npx","args":["-y","@linear/mcp-server-linear"],"env":{"LINEAR_API_KEY":"${{ inputs.linear_api_key }}"}}}}'
+
+        ADDITIONAL='${{ inputs.additional_mcp_config }}'
+        if [ -n "$ADDITIONAL" ]; then
+          echo "$BASE" | jq --argjson extra "$ADDITIONAL" '.mcpServers += $extra' > .mcp.json
+        else
+          echo "$BASE" | jq '.' > .mcp.json
+        fi
 
     - name: Monitor Datadog and Create Linear Tickets
       id: monitor
@@ -101,7 +109,7 @@ runs:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         github_token: ${{ inputs.github_token }}
         show_full_output: true
-        claude_args: "${{ inputs.claude_model != '' && format('--model {0} ', inputs.claude_model) || '' }}--allowedTools Bash,Read,Write,mcp__linear-server__list_issues,mcp__linear-server__create_issue,mcp__linear-server__get_issue"
+        claude_args: "${{ inputs.claude_model != '' && format('--model {0} ', inputs.claude_model) || '' }}--allowedTools Bash,Read,Write,mcp__linear-server__list_issues,mcp__linear-server__create_issue,mcp__linear-server__get_issue${{ inputs.additional_allowed_tools != '' && format(',{0}', inputs.additional_allowed_tools) || '' }}"
         prompt: |
           You are a DevOps monitoring agent. Check Datadog for errors in the last ${{ inputs.hours_back }} hour(s) and create Linear tickets.
 
@@ -219,6 +227,11 @@ runs:
           ## Related Links
           - [Datadog Logs](https://app.datadoghq.com/logs?query=...)
           ```
+
+          ${{ inputs.rca_prompt_file != '' && format('
+          ### Step 5.5: Enhanced Root Cause Analysis
+          Before creating tickets, read the file at `{0}` using the Read tool. Follow the instructions in that file to perform a deeper root cause analysis using the available MCP tools. Include the findings from this analysis in each ticket''s "Root Cause Analysis" and "Suggested Fix" sections instead of guessing.
+          ', inputs.rca_prompt_file) || '' }}
 
           ### Step 6: Output Results
           Write a structured summary:

--- a/action.yml
+++ b/action.yml
@@ -230,7 +230,10 @@ runs:
 
           ${{ inputs.rca_prompt_file != '' && format('
           ### Step 5.5: Enhanced Root Cause Analysis
-          Before creating tickets, read the file at `{0}` using the Read tool. Follow the instructions in that file to perform a deeper root cause analysis using the available MCP tools. Include the findings from this analysis in each ticket''s "Root Cause Analysis" and "Suggested Fix" sections instead of guessing.
+          Before creating tickets, read the file at `{0}` using the Read tool.
+          Follow the instructions in that file with `mode: ci` to perform a deeper root cause analysis using the available MCP tools.
+          Use the error patterns and service names from the Datadog logs to correlate with telemetry data.
+          Your only goal from this file is to produce actionable RCA text — include the findings in each ticket''s "Root Cause Analysis" and "Suggested Fix" sections instead of guessing.
           ', inputs.rca_prompt_file) || '' }}
 
           ### Step 6: Output Results

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: 'Claude model override (leave empty for default)'
     required: false
     default: ''
+  linear_label_ids:
+    description: 'Comma-separated Linear label UUIDs to apply to created tickets (e.g. "label-uuid-1,label-uuid-2")'
+    required: false
+    default: ''
   slack_webhook_url:
     description: 'Slack incoming webhook URL. If provided, sends a summary notification.'
     required: false
@@ -171,6 +175,7 @@ runs:
           - team: "${{ inputs.linear_team }}"
           - title: "${{ inputs.ticket_prefix }} <concise error title>" (avoid parentheses in titles — use dashes instead)
           - priority: 2 (High) for critical errors, 3 (Normal) for regular errors
+          ${{ inputs.linear_label_ids != '' && format('- labelIds: [{0}]', inputs.linear_label_ids) || '' }}
 
           **IMPORTANT**: After calling `create_issue`, capture the `id`, `identifier`, and `url` from the response.
 

--- a/action.yml
+++ b/action.yml
@@ -230,10 +230,14 @@ runs:
 
           ${{ inputs.rca_prompt_file != '' && format('
           ### Step 5.5: Enhanced Root Cause Analysis
-          Before creating tickets, read the file at `{0}` using the Read tool.
-          Follow the instructions in that file with `mode: ci` to perform a deeper root cause analysis using the available MCP tools.
-          Use the error patterns and service names from the Datadog logs to correlate with telemetry data.
-          Your only goal from this file is to produce actionable RCA text — include the findings in each ticket''s "Root Cause Analysis" and "Suggested Fix" sections instead of guessing.
+          Before creating tickets, perform a deeper root cause analysis for EACH error group:
+
+          1. **Read the RCA instructions** from `{0}` using the Read tool.
+          2. **Build a context block** for each error group from the Datadog logs you already have. Extract all structured identifiers and metadata from the log attributes (e.g., any UUIDs, trace IDs, request IDs, service names, file paths, function names, timestamps). Include the full error message and pattern.
+          3. **Follow the RCA file instructions** passing ALL extracted context so the instructions can use whatever identifiers are relevant to query their telemetry backend. This is a non-interactive, automated run — do not prompt for input, do not save files locally, and produce only text output. If the file expects identifiers you don''t have, skip that error group''s deep RCA and fall back to the Datadog-only analysis.
+          4. **Use the RCA output** to enrich each ticket''s "Root Cause Analysis" and "Suggested Fix" sections with evidence-backed findings instead of guessing.
+
+          The RCA file may reference tools from the additional MCP servers configured for this run. Use them as instructed.
           ', inputs.rca_prompt_file) || '' }}
 
           ### Step 6: Output Results


### PR DESCRIPTION
## Summary
- Restructures Step 5.5 RCA handoff to explicitly extract all identifiers and metadata from Datadog log attributes before passing to the RCA file
- Removes hard dependency on `mode: ci` terminology — describes desired behavior (non-interactive, text output only) generically so the action doesn't leak consumer-specific concepts
- Adds graceful fallback: if the RCA file expects identifiers not present in the logs, skip deep RCA for that error group

## Test plan
- [ ] Run the ai-oncall workflow with `mode: test` and verify RCA enrichment still works with Logfire
- [ ] Verify the action works without `rca_prompt_file` (no regression on default behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)